### PR TITLE
3.0.0.3: Fix for MissingMethodException. It was caused by an older de…

### DIFF
--- a/SRTHost/Program.cs
+++ b/SRTHost/Program.cs
@@ -19,6 +19,7 @@ namespace SRTHost
         private static FileStream logFileStream;
         private static LogTextWriter logTextWriter;
         private static CommandLineProcessor commandLineProcessor;
+        public static string loadSpecificProvider = string.Empty;
 
         private static int settingUpdateRate = 33; // Default to 33ms.
 
@@ -52,7 +53,6 @@ namespace SRTHost
                 Console.WriteLine("{0} v{1} {2}", srtHostFileVersionInfo.ProductName, srtHostFileVersionInfo.ProductVersion, (Environment.Is64BitProcess) ? "64-bit (x64)" : "32-bit (x86)");
                 Console.WriteLine(new string('-', 50));
 
-                string loadSpecificProvider = string.Empty;
                 foreach (KeyValuePair<string, string?> kvp in (commandLineProcessor = new CommandLineProcessor(args)))
                 {
                     Console.WriteLine("Command-line arguments:");

--- a/SRTHost/SRTHost.csproj
+++ b/SRTHost/SRTHost.csproj
@@ -12,8 +12,8 @@
     <Copyright>Copyright © 2021 Travis J. Gutjahr</Copyright>
     <Product>SRT Host</Product>
     <Description>A plugin host for various informational SpeedRun Tools.</Description>
-    <Version>3.0.0.2</Version>
-    <FileVersion>3.0.0.2</FileVersion>
+    <Version>3.0.0.3</Version>
+    <FileVersion>3.0.0.3</FileVersion>
     <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <DebugType>embedded</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
…pendency being loaded first and then being kept. Specifically an older ProcessMemory was loaded by the first plugin to use it and then when another plugin that used a newer version with additional features was loaded, the old version was already loaded and when the new method gets called, it isn't there. This is now worked around by adjusting the loading order.