### PR TITLE
3.1.0.0: Working by checking all loaded LoadContexts to see if there …

### DIFF
--- a/SRTHost/Program.cs
+++ b/SRTHost/Program.cs
@@ -113,7 +113,7 @@ namespace SRTHost
                             .EnumerateDirectories("*", SearchOption.TopDirectoryOnly)
                             .Select((DirectoryInfo pluginDir) => pluginDir.EnumerateFiles(string.Format("{0}.dll", pluginDir.Name), SearchOption.TopDirectoryOnly).FirstOrDefault())
                             .Where((FileInfo pluginAssemblyFileInfo) => pluginAssemblyFileInfo != null)
-                            .Select((FileInfo pluginAssemblyFileInfo) => PluginLoadingStatics.LoadPlugin(new PluginLoadContext(pluginAssemblyFileInfo.Directory.FullName, pluginAssemblyFileInfo.Directory.Parent.FullName), pluginAssemblyFileInfo.FullName))
+                            .Select((FileInfo pluginAssemblyFileInfo) => PluginLoadingStatics.LoadPlugin(new PluginLoadContext(pluginAssemblyFileInfo.Directory), pluginAssemblyFileInfo.FullName))
                             .Where((Assembly pluginAssembly) => pluginAssembly != null)
                             .SelectMany((Assembly pluginAssembly) => PluginLoadingStatics.CreatePlugins(pluginAssembly)).ToArray();
                     }
@@ -124,7 +124,7 @@ namespace SRTHost
                             .Select((DirectoryInfo pluginDir) => pluginDir.EnumerateFiles(string.Format("{0}.dll", pluginDir.Name), SearchOption.TopDirectoryOnly).FirstOrDefault())
                             .Where((FileInfo pluginAssemblyFileInfo) => pluginAssemblyFileInfo != null)
                             .Where((FileInfo pluginAssemblyFileInfo) => !pluginAssemblyFileInfo.Name.Contains("Provider", StringComparison.InvariantCultureIgnoreCase) || (pluginAssemblyFileInfo.Name.Contains("Provider", StringComparison.InvariantCultureIgnoreCase) && pluginAssemblyFileInfo.Name.Equals(string.Format("{0}.dll", loadSpecificProvider), StringComparison.InvariantCultureIgnoreCase)))
-                            .Select((FileInfo pluginAssemblyFileInfo) => PluginLoadingStatics.LoadPlugin(new PluginLoadContext(pluginAssemblyFileInfo.Directory.FullName, pluginAssemblyFileInfo.Directory.Parent.FullName), pluginAssemblyFileInfo.FullName))
+                            .Select((FileInfo pluginAssemblyFileInfo) => PluginLoadingStatics.LoadPlugin(new PluginLoadContext(pluginAssemblyFileInfo.Directory), pluginAssemblyFileInfo.FullName))
                             .Where((Assembly pluginAssembly) => pluginAssembly != null)
                             .SelectMany((Assembly pluginAssembly) => PluginLoadingStatics.CreatePlugins(pluginAssembly)).ToArray();
                     }

--- a/SRTHost/SRTHost.csproj
+++ b/SRTHost/SRTHost.csproj
@@ -14,7 +14,7 @@
     <Description>A plugin host for various informational SpeedRun Tools.</Description>
     <Version>3.1.0.0</Version>
     <FileVersion>3.1.0.0</FileVersion>
-    <AssemblyVersion>3.1.0.0</AssemblyVersion>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 


### PR DESCRIPTION
…are any load contexts matching the name of the DLL we're attempting to load. That means the plugin we're trying to load was already loaded in another context and we should load the Assembly from that context so we don't load it twice and cause casting issues.